### PR TITLE
Make 2fa required error readable

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -36,3 +36,6 @@ sed -i '/license/a long_description_content_type="text/markdown",' ./setup.py
 
 # Remove messily pasted markdown at top of every file
 find vrchatapi -type f -exec sed -i '/VRChat API Banner/d' {} \;
+
+# Make 2fa required error readable
+patch ./vrchatapi/rest.py < ./patches/error_2fa_verify_readable.patch

--- a/patches/error_2fa_verify_readable.patch
+++ b/patches/error_2fa_verify_readable.patch
@@ -1,0 +1,15 @@
+diff --git a/vrchatapi/rest.py b/vrchatapi/rest.py
+index aac58f3..703ae1b 100644
+--- a/vrchatapi/rest.py
++++ b/vrchatapi/rest.py
+@@ -239,6 +239,10 @@ class RESTClientObject(object):
+ 
+             raise ApiException(http_resp=r)
+ 
++        if re.match(b'{"\w{21}":\["totp","otp"]}', r.data) is not None:
++            r.reason = "2 Factor Authentication verification is required"
++            raise UnauthorizedException(http_resp=r)
++
+         return r
+ 
+     def GET(self, url, headers=None, query_params=None, _preload_content=True,

--- a/vrchatapi/rest.py
+++ b/vrchatapi/rest.py
@@ -239,6 +239,10 @@ class RESTClientObject(object):
 
             raise ApiException(http_resp=r)
 
+        if re.match(b'{"\w{21}":\["totp","otp"]}', r.data) is not None:
+            r.reason = "2 Factor Authentication verification is required"
+            raise UnauthorizedException(http_resp=r)
+
         return r
 
     def GET(self, url, headers=None, query_params=None, _preload_content=True,


### PR DESCRIPTION
Patches in a check for the 200 2fa verification response, and raises a readable exception for it
Decided to patch the main request method in rest.py as this can be returned in (all?) requests requiring auth

Let me know if I should make any changes